### PR TITLE
support deprecated fields in generating yaml from proto

### DIFF
--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -87,7 +87,13 @@ defmodule Protobuf.Protoc.Generator.Message do
     |> Enum.map(fn f ->
       type = Util.trans_type(f[:type])
 
-      {f[:name], f[:number], repeated: f[:label] === "repeated", type: type, oneof: f[:oneof]}
+      opts = Map.get(f, :opts, %{})
+
+      {f[:name], f[:number],
+       repeated: f[:label] === "repeated",
+       type: type,
+       oneof: f[:oneof],
+       deprecated: opts[:deprecated]}
     end)
   end
 

--- a/priv/templates/message.yml.eex
+++ b/priv/templates/message.yml.eex
@@ -5,11 +5,14 @@
 <%= for {fname, _, opts} <- fields do %>
 <%= if (not String.starts_with?(name, "request")) and opts[:type] == "any" do %>    - name: <%= fname %>
       type: <%= if opts[:repeated] do %><%= "[#{opts[:type]}]" %><% else %><%= opts[:type] %><% end %>
-      meta: resolver=google_protobuf_any 
+      meta: resolver=google_protobuf_any <%= if opts[:deprecated] do %>deprecated=true<% end %>
+<% else %><%= if opts[:deprecated] do %>    - name: <%= fname %>
+      type: <%= if opts[:repeated] do %><%= "[#{opts[:type]}]" %><% else %><%= opts[:type] %><% end %>
+      meta: deprecated=true
 <% else %>
     - name: <%= fname %>
       type: <%= if opts[:repeated] do %><%= "[#{opts[:type]}]" %><% else %><%= opts[:type] %><% end %>
-<% end %><% end %>
+<% end %><% end %><% end %>
 <% else %>
   fields: []
 <% end %>


### PR DESCRIPTION
This pr support the deprecated fields in generating yaml from proto. 

For example: 

Proto: 

```proto
message AccountState {
   ....
    WalletType type = 6 [ deprecated = true ];
}


message WalletInfo {
    WalletType type = 1 [ deprecated = true ];
    ....
}
```


Generated YAML: 


```yaml
- name: account_state
  type: output
  fields:
     - name: type
      type: wallet_type
      meta: deprecated=true


- name: wallet_info
  type: output
  fields:
     - name: type
      type: wallet_type
      meta: deprecated=true
```


